### PR TITLE
Use inputContext to update UI on click

### DIFF
--- a/src/ui/classic/inputwindow.cpp
+++ b/src/ui/classic/inputwindow.cpp
@@ -635,13 +635,14 @@ void InputWindow::click(int x, int y) {
     if (!candidateList) {
         return;
     }
+    bool needUpdateUI = false;
     for (size_t idx = 0, e = candidateRegions_.size(); idx < e; idx++) {
         if (candidateRegions_[idx].contains(x, y)) {
             const auto *candidate =
                 nthCandidateIgnorePlaceholder(*candidateList, idx);
             if (candidate) {
                 candidate->select(inputContext);
-                update(inputContext);
+                needUpdateUI = true;
             }
             break;
         }
@@ -649,15 +650,15 @@ void InputWindow::click(int x, int y) {
     if (auto *pageable = candidateList->toPageable()) {
         if (pageable->hasPrev() && prevRegion_.contains(x, y)) {
             pageable->prev();
-            inputContext->updateUserInterface(
-                UserInterfaceComponent::InputPanel);
-            return;
-        }
-        if (pageable->hasNext() && nextRegion_.contains(x, y)) {
+            needUpdateUI = true;
+        } else if (pageable->hasNext() && nextRegion_.contains(x, y)) {
             pageable->next();
-            inputContext->updateUserInterface(
-                UserInterfaceComponent::InputPanel);
+            needUpdateUI = true;
         }
+    }
+
+    if (needUpdateUI) {
+        inputContext->updateUserInterface(UserInterfaceComponent::InputPanel);
     }
 }
 

--- a/src/ui/classic/waylandinputwindow.cpp
+++ b/src/ui/classic/waylandinputwindow.cpp
@@ -35,7 +35,6 @@ WaylandInputWindow::WaylandInputWindow(WaylandUI *ui)
                                     uint32_t state) {
         if (state == WL_POINTER_BUTTON_STATE_PRESSED && button == BTN_LEFT) {
             click(x, y);
-            repaint();
         }
     });
     window_->hover().connect([this](int x, int y) {


### PR DESCRIPTION
Unified update process for mouse clicks with other key input.

Fcitx-anthy calls `InputContext::updateUserInterface` when key input event occurred.
This triggers the following callback, which includes `InputWindow::Update`.

https://github.com/clear-code/fcitx5/blob/c4712b173f7cced6e014e4b1c45e585acdd40ce5/src/lib/fcitx/instance.cpp#L1174-L1187
